### PR TITLE
New utility for no js support

### DIFF
--- a/app/views/cdn-documentation/components.html
+++ b/app/views/cdn-documentation/components.html
@@ -104,10 +104,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <p class="govuk-body govuk-!-padding-top-7">Hide an element when there is no JavaScript support.</p>
-    <p class="govuk-body-s">Example shown: <abbr>GDS</abbr> <b>back link</b> hidden when there is no JavaScript support.</p>
+    <p class="govuk-body govuk-!-padding-top-7">Das version of <abbr>GDS</abbr> JavaScript <b>back link</b>.</p>
+    <p class="govuk-body-s">(Will not display without JavaScript support).</p>
 
-    <a href="#" class="govuk-back-link das-nojs-hide">Back</a>
+    <div class="das-js-back-link"></div>
 
   </div>
 </div>

--- a/app/views/cdn-documentation/components.html
+++ b/app/views/cdn-documentation/components.html
@@ -104,7 +104,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <p class="govuk-body govuk-!-padding-top-7">Make a <abbr>GDS</abbr> <b>back link</b> hidden when there is no JavaScript support.</p>
+    <p class="govuk-body govuk-!-padding-top-7">Hide an element when there is no JavaScript support.</p>
+    <p class="govuk-body-s">Example shown: <abbr>GDS</abbr> <b>back link</b> hidden when there is no JavaScript support.</p>
 
     <a href="#" class="govuk-back-link das-nojs-hide">Back</a>
 

--- a/app/views/cdn-documentation/components.html
+++ b/app/views/cdn-documentation/components.html
@@ -104,6 +104,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <p class="govuk-body govuk-!-padding-top-7">Make a <abbr>GDS</abbr> <b>back link</b> hidden when there is no JavaScript support.</p>
+
+    <a href="#" class="govuk-back-link das-nojs-hide">Back</a>
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
     <h2 class="govuk-heading-m govuk-!-margin-top-6 govuk-!-margin-bottom-3">
       Buttons
     </h2>

--- a/src/das/sass/core/_utilities.scss
+++ b/src/das/sass/core/_utilities.scss
@@ -41,7 +41,7 @@
   }
 }
 
-.das-js-show {
+.das-js-show {/*hides elements if js is NOT enabled */
   display: none;
   .js-enabled & {
     display: block;
@@ -75,12 +75,6 @@
       clip-path: inset(50%) !important;
       border: 0 !important;
       white-space: nowrap !important;
-  }
-}
-
-body:not(.js-enabled){
-  .das-nojs-hide {/*hide if js is NOT enabled */
-    display: none;
   }
 }
 

--- a/src/das/sass/core/_utilities.scss
+++ b/src/das/sass/core/_utilities.scss
@@ -78,6 +78,12 @@
   }
 }
 
+body:not(.js-enabled){
+  .das-nojs-hide {/*hide if js is NOT enabled */
+    display: none;
+  }
+}
+
 // Utility hidden class, for server side code
 .das-hidden {
   display: none;


### PR DESCRIPTION
This is a new das class to use when there is a requirement to hide an element if JS is disabled. Came about by a requirement from the 'commitments projects' to use GDS back links, but hidden when JS was disabled. 